### PR TITLE
fix(candle): resolve import paths for Qwen3 classification heads

### DIFF
--- a/backends/candle/src/models/flash_qwen3.rs
+++ b/backends/candle/src/models/flash_qwen3.rs
@@ -1,6 +1,7 @@
 use crate::flash_attn::flash_attn_varlen;
 use crate::layers::{get_cos_sin, get_inv_freqs, index_select, HiddenAct, Linear, RMSNorm};
-use crate::models::{ClassificationHead, Model, Qwen3ClassificationHead, Qwen3Config};
+use crate::models::{Model, Qwen3Config};
+use crate::models::qwen3::{ClassificationHead, Qwen3ClassificationHead};
 use candle::{DType, Device, IndexOp, Result, Tensor};
 use candle_nn::{Embedding, Module, VarBuilder};
 use candle_rotary::apply_rotary_inplace;


### PR DESCRIPTION
# What does this PR do?

Hi @kozistr! Following up on our discussion in #835, I encountered a build blockage (`error[E0432]`) when compiling the `candle` backend locally. 

```
> 2.352 warning: ignoring -C extra-filename flag due to -o flag
> 2.352 
> 2.352 error[E0432]: unresolved imports `crate::models::ClassificationHead`, `crate::models::Qwen3ClassificationHead`
> 2.352  --> backends/candle/src/models/flash_qwen3.rs:3:21
> 2.352   |
> 2.352 3 | use crate::models::{ClassificationHead, Model, Qwen3ClassificationHead, Qwen3Config};
> 2.352   |                     ^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^ no `Qwen3ClassificationHead` in `models`
> 2.352   |                     |
> 2.352   |                     no `ClassificationHead` in `models`
> 2.352   |
> 2.352   = help: consider importing one of these traits instead:
> 2.352           crate::models::bert::ClassificationHead
> 2.352           crate::models::distilbert::ClassificationHead
> 2.352           crate::models::jina::ClassificationHead
> 2.352           crate::models::modernbert::ClassificationHead
> 2.352           crate::models::qwen3::ClassificationHead
> 2.352   = help: consider importing this struct instead:
> 2.352           crate::models::qwen3::Qwen3ClassificationHead
> 2.352 
> 2.352 For more information about this error, try `rustc --explain E0432`.
> 2.353 warning: `text-embeddings-backend-candle` (lib) generated 1 warning
> 2.353 error: could not compile `text-embeddings-backend-candle` (lib) due to 1 previous error; 1 warning emitted
> 2.353 warning: build failed, waiting for other jobs to finish...
```

The build was failing due to unresolved imports for `ClassificationHead` and `Qwen3ClassificationHead` in `flash_qwen3.rs`. This commit updates the import paths to correctly reference the `qwen3` module instead of the root `models` module, preventing namespace collisions and fixing the build block.

Feel free to merge this into your `feature/qwen3-reranker` branch so others can build it smoothly!

Related to #835

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. (Discussed in PR #835)
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

@kozistr